### PR TITLE
fixed privacy dropdown

### DIFF
--- a/src/components/groups/CreateGroup.js
+++ b/src/components/groups/CreateGroup.js
@@ -137,9 +137,9 @@ const CreateGroup = props => {
                     {window.location.pathname === '/editgroup'
                         ? <option value={values.privacy_setting}>{privacy} </option>
                         : <option value='' disabled hidden>Choose Privacy setting...</option>}
-                    {privacy !== "Public" ? <option value='public'>Public</option> : null}
-                    {privacy !== "Private" ? <option value='private'>Private</option> : null}
-                    {privacy !== "Hidden" ? <option value='hidden'>Hidden</option> : null}
+                    {privacy !== "Public" && privacy !== undefined ? <option value='public'>Public</option> : null}
+                    {privacy !== "Private" && privacy !== undefined ? <option value='private'>Private</option> : null}
+                    {privacy !== "Hidden" && privacy !== undefined ? <option value='hidden'>Hidden</option> : null}
                 </Form.Field>
                 <div>
                     {isLoading


### PR DESCRIPTION
# Description

Privacy dropdown now works correctly when editing a group.

## Checklist

Remove any items which are not applicable.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works AND the tests pass
